### PR TITLE
App icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:allowBackup="true"
         android:backupAgent=".BackupAgent"
         android:fullBackupOnly="true"
-        android:icon="@drawable/icon"
+        android:icon="@mipmap/icon"
         android:label="@string/app_name"
         android:theme="@style/Theme.KitMensa"
         tools:ignore="GoogleAppIndexingWarning">

--- a/app/src/main/res/mipmap-anydpi-v26/icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/icon.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@color/icon_background"/>
+  <foreground>
+      <inset
+          android:drawable="@drawable/icon"
+          android:inset="27%" />
+  </foreground>
+  <monochrome>
+      <inset
+          android:drawable="@drawable/icon_white"
+          android:inset="33%" />
+  </monochrome>
+</adaptive-icon>

--- a/app/src/main/res/values/colors_icon.xml
+++ b/app/src/main/res/values/colors_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="icon_background">#ffffff</color>
+</resources>


### PR DESCRIPTION
mainly, this PR is for enabling monochrome app icon support. i use the existing "@drawable/icon_white" for that. the normal app icon should not have changed with this new code (xml).

| | before | after |
| ---- | ---- | ---- |
| normal | <img width="482" height="916" alt="colored-old" src="https://github.com/user-attachments/assets/758690f5-1fa1-4ed1-82e9-6f5ca2f01293" />  | <img width="482" height="916" alt="colored-new" src="https://github.com/user-attachments/assets/39a7c32f-bfa3-4218-a059-69ae940978e5" /> |
| monochrome | <img width="482" height="916" alt="monochrome-old" src="https://github.com/user-attachments/assets/20fead6e-d214-49c4-9496-ef0aaecb074f" /> | <img width="482" height="916" alt="monochrome-new" src="https://github.com/user-attachments/assets/18a2b168-754e-453f-86cc-d0dc507bf5b0" /> |